### PR TITLE
Fixed issue with example

### DIFF
--- a/proposals/async-streams.md
+++ b/proposals/async-streams.md
@@ -277,7 +277,7 @@ namespace System.Threading.Tasks
             public ConfiguredAsyncEnumerator<T> GetAsyncEnumerator() =>
                 new ConfiguredAsyncEnumerator<T>(_enumerable.GetAsyncEnumerator(), _continueOnCapturedContext);
 
-            public struct Enumerator
+            public struct ConfiguredAsyncEnumerator<T>
             {
                 private readonly IAsyncEnumerator<T> _enumerator;
                 private readonly bool _continueOnCapturedContext;


### PR DESCRIPTION
Incorrect name was given to embedded class (and generic parameter was missing)